### PR TITLE
pin JB to 0.12.3

### DIFF
--- a/tutorial/requirements.txt
+++ b/tutorial/requirements.txt
@@ -1,3 +1,3 @@
-jupyter-book
+jupyter-book==0.12.3
 pandas
 dash


### PR DESCRIPTION
Revert CSS changes to dropdown.

We are now locked into Juptyerbook 0.12.3 so if we make future changes to the text and want to upgrade to a newer version of JB (like 0.13.1), these are the changes that need to be made (at minimum):

```
1. dropdown style

    :container: + shadow

    changed to 

    :class-container: sd-shadow-lg

2. dropdown title

    :title: bg-primary text-white font-weight-bold

    changed to

    :color: primary
```